### PR TITLE
CONFSERVER-82911 Back-port https://github.com/hunterhacker/jdom/pull/188

### DIFF
--- a/core/src/java/org/jdom/input/SAXBuilder.java
+++ b/core/src/java/org/jdom/input/SAXBuilder.java
@@ -758,16 +758,8 @@ public class SAXBuilder {
     private void setFeaturesAndProperties(XMLReader parser,
                                           boolean coreFeatures)
                                                         throws JDOMException {
-        // Set any user-specified features on the parser.
-        Iterator iter = features.keySet().iterator();
-        while (iter.hasNext()) {
-            String  name  = (String)iter.next();
-            Boolean value = (Boolean)features.get(name);
-            internalSetFeature(parser, name, value.booleanValue(), name);
-        }
-
         // Set any user-specified properties on the parser.
-        iter = properties.keySet().iterator();
+        Iterator iter = properties.keySet().iterator();
         while (iter.hasNext()) {
             String name = (String)iter.next();
             internalSetProperty(parser, name, properties.get(name), name);

--- a/core/src/java/org/jdom/input/SAXBuilder.java
+++ b/core/src/java/org/jdom/input/SAXBuilder.java
@@ -810,6 +810,14 @@ public class SAXBuilder {
         }
         catch (SAXNotRecognizedException e) { /* Ignore... */ }
         catch (SAXNotSupportedException  e) { /* Ignore... */ }
+
+        // Set any user-specified features on the parser.
+        iter = features.keySet().iterator();
+        while (iter.hasNext()) {
+            String  name  = (String)iter.next();
+            Boolean value = (Boolean)features.get(name);
+            internalSetFeature(parser, name, value.booleanValue(), name);
+        }
     }
 
     /**

--- a/test/src/java/org/jdom/test/cases/input/TestSAXBuilder.java
+++ b/test/src/java/org/jdom/test/cases/input/TestSAXBuilder.java
@@ -700,6 +700,25 @@ extends junit.framework.TestCase
 //		}
 //	}
 
+	public void testSetExternalFeature() {
+		String feature = "http://xml.org/sax/features/external-general-entities";
+		MySAXBuilder sb = new MySAXBuilder();
+		try {
+			sb.setFeature(feature, true);
+			XMLReader reader = sb.createParser();
+			assertNotNull(reader);
+			assertTrue(reader.getFeature(feature));
+			sb.setFeature(feature, false);
+			reader = sb.createParser();
+			assertNotNull(reader);
+			assertFalse(reader.getFeature(feature));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Could not create parser: " + e.getMessage());
+		}
+	}
+
 	public void testSetProperty() {
 		LexicalHandler lh = new LexicalHandler() {
 


### PR DESCRIPTION
Back-porting the above PR from JDOM 2.x upstream. 

It's not a simple cherry-pick, since there have been too many intervening code changes, but the essence of it is simple.

The bug is that if client code sets the `http://xml.org/sax/features/external-general-entities` feature on the `SAXBuilder`, this can be silently over-written based on the value of the `expand` property of `SAXBuilder`. The upstream PR moves the logic which sets the features from before the `expand` logic, to after after. 

There's also the added unit test, which verifies the fix.